### PR TITLE
Allow creation of new stock items in the admin backend

### DIFF
--- a/src/app/code/community/FireGento/MultiStock/Block/Adminhtml/Stock/Edit/Form.php
+++ b/src/app/code/community/FireGento/MultiStock/Block/Adminhtml/Stock/Edit/Form.php
@@ -33,10 +33,14 @@ class FireGento_MultiStock_Block_Adminhtml_Stock_Edit_Form extends Mage_Adminhtm
      */
     protected function _prepareForm()
     {
+        $stockId = '';
+        if($this->getRequest()->getActionName() == 'edit') {
+            $stockId = array('stock_id' => $this->getRequest()->getParam('stock_id'));
+        }
         $form = new Varien_Data_Form(
             array(
             'id' => 'edit_form',
-            'action' => $this->getUrl('*/*/save', array('stock_id' => $this->getRequest()->getParam('stock_id'))),
+            'action' => $this->getUrl('*/*/save', $stockId),
             'method' => 'post',
             'enctype' => 'multipart/form-data',
             )

--- a/src/app/code/community/FireGento/MultiStock/Block/Adminhtml/Stock/Edit/Tab/General.php
+++ b/src/app/code/community/FireGento/MultiStock/Block/Adminhtml/Stock/Edit/Tab/General.php
@@ -44,8 +44,7 @@ class FireGento_MultiStock_Block_Adminhtml_Stock_Edit_Tab_General extends Mage_A
             'firegento_multistock_stock_form', array('legend' => $this->__('General'))
         );
         $fieldset->addField(
-            'stock_id', 'text',
-            array('label' => $this->__('Stock ID'), 'name' => 'stock_id', 'class' => 'required-entry', 'required' => true)
+            'stock_id', 'label', array('label' => $this->__('Stock ID'), 'name' => 'stock_id')
         );
 
         $fieldset->addField(

--- a/src/app/code/community/FireGento/MultiStock/Block/Adminhtml/Stock/Edit/Tab/General.php
+++ b/src/app/code/community/FireGento/MultiStock/Block/Adminhtml/Stock/Edit/Tab/General.php
@@ -44,7 +44,8 @@ class FireGento_MultiStock_Block_Adminhtml_Stock_Edit_Tab_General extends Mage_A
             'firegento_multistock_stock_form', array('legend' => $this->__('General'))
         );
         $fieldset->addField(
-            'stock_id', 'label', array('label' => $this->__('Stock ID'), 'name' => 'stock_id')
+            'stock_id', 'text',
+            array('label' => $this->__('Stock ID'), 'name' => 'stock_id', 'class' => 'required-entry', 'required' => true)
         );
 
         $fieldset->addField(

--- a/src/app/code/community/FireGento/MultiStock/Block/Adminhtml/Stock/Edit/Tab/General.php
+++ b/src/app/code/community/FireGento/MultiStock/Block/Adminhtml/Stock/Edit/Tab/General.php
@@ -38,14 +38,22 @@ class FireGento_MultiStock_Block_Adminhtml_Stock_Edit_Tab_General extends Mage_A
     protected function _prepareForm()
     {
         $data = $this->helper('firegento_multistock')->getCurrentStock();
+
         $form = new Varien_Data_Form();
 
         $fieldset = $form->addFieldset(
             'firegento_multistock_stock_form', array('legend' => $this->__('General'))
         );
+        /*
         $fieldset->addField(
-            'stock_id', 'label', array('label' => $this->__('Stock ID'), 'name' => 'stock_id')
+            'stock_id_text', 'note', array('label' => $this->__('Stock ID'), 'name' => 'stock_id_text', 'text' => $this->helper('firegento_multistock')->getNextStockId())
         );
+        $fieldset->addField(
+            'stock_id', 'hidden',
+            array('value' => $this->helper('firegento_multistock')->getNextStockId())
+        );
+        */
+
 
         $fieldset->addField(
             'stock_name', 'text',
@@ -54,7 +62,9 @@ class FireGento_MultiStock_Block_Adminhtml_Stock_Edit_Tab_General extends Mage_A
         );
 
         $this->setForm($form);
-        $form->setValues($data);
+        if ($data) {
+            $form->setValues($data);
+        }
 
         return parent::_prepareForm();
     }

--- a/src/app/code/community/FireGento/MultiStock/Helper/Data.php
+++ b/src/app/code/community/FireGento/MultiStock/Helper/Data.php
@@ -49,4 +49,13 @@ class FireGento_MultiStock_Helper_Data extends Mage_Core_Helper_Data
     {
         Mage::register(self::CURRENT_STOCK, $stock);
     }
+
+    public function getNextStockId()
+    {
+        $tableName = 'information_schema.tables';
+        $db = Mage::getConfig()->getResourceConnectionConfig('default_setup')->dbname;
+        $read = Mage::getSingleton('core/resource')->getConnection('core_read');
+        $result =$read->fetchRow("SELECT AUTO_INCREMENT FROM $tableName WHERE table_schema = '$db' AND table_name = '".Mage::getSingleton('core/resource')->getTableName('cataloginventory/stock')."'");
+        return $result['AUTO_INCREMENT'];
+    }
 }

--- a/src/app/code/community/FireGento/MultiStock/Model/Stock.php
+++ b/src/app/code/community/FireGento/MultiStock/Model/Stock.php
@@ -36,7 +36,7 @@ class FireGento_MultiStock_Model_Stock extends Mage_CatalogInventory_Model_Stock
     public function getId()
     {
         if (!$this->hasData('stock_id')) {
-            $this->setData('stock_id', self::DEFAULT_STOCK_ID);
+            $this->setData('stock_id', Mage::helper('firegento_multistock')->getNextStockId());
         }
 
         return $this->getData('stock_id');

--- a/src/app/code/community/FireGento/MultiStock/Model/Stock.php
+++ b/src/app/code/community/FireGento/MultiStock/Model/Stock.php
@@ -31,14 +31,10 @@ class FireGento_MultiStock_Model_Stock extends Mage_CatalogInventory_Model_Stock
     /**
      * Get the id.
      *
-     * @return mixed
+     * @return null|int
      */
     public function getId()
     {
-        if (!$this->hasData('stock_id')) {
-            $this->setData('stock_id', Mage::helper('firegento_multistock')->getNextStockId());
-        }
-
         return $this->getData('stock_id');
     }
 

--- a/src/app/code/community/FireGento/MultiStock/controllers/Adminhtml/MultistockController.php
+++ b/src/app/code/community/FireGento/MultiStock/controllers/Adminhtml/MultistockController.php
@@ -107,7 +107,7 @@ class FireGento_MultiStock_Adminhtml_MultistockController extends Mage_Adminhtml
     }
 
     /**
-     * save alle stocks at once
+     * save all stocks at once
      */
     public function saveAllAction()
     {

--- a/src/app/code/community/FireGento/MultiStock/controllers/Adminhtml/StockController.php
+++ b/src/app/code/community/FireGento/MultiStock/controllers/Adminhtml/StockController.php
@@ -55,16 +55,26 @@ class FireGento_MultiStock_Adminhtml_StockController extends Mage_Adminhtml_Cont
     }
 
     /**
-     * newAction
+     * Action for creating new stock entries.
      *
      * @return void
      */
     public function newAction()
     {
-        // We just forward the new action to a blank edit form
-        $this->_forward('edit');
-    }
+        $this->_initAction();
 
+        // Get Next AutoInc id
+        $id    = Mage::helper('firegento_multistock')->getNextStockId();
+        $model = Mage::getModel('firegento_multistock/stock');
+
+        $model->setData('stock_id', $id);
+        $this->_title($this->__('New Stock'));
+
+        $this->_initAction()->_addBreadcrumb(
+            $this->__('New Stock'),
+            $this->__('New Stock')
+        )->renderLayout();
+    }
     /**
      * Edit stock entry controller
      *
@@ -108,19 +118,19 @@ class FireGento_MultiStock_Adminhtml_StockController extends Mage_Adminhtml_Cont
      */
     public function saveAction()
     {
+
         $stockId      = $this->getRequest()->getParam('stock_id');
         $redirectBack = $this->getRequest()->getParam('back', false);
         if ($postData = $this->getRequest()->getPost()) {
             /** @var $stock FireGento_MultiStock_Model_Stock */
-            $stock = Mage::getSingleton('firegento_multistock/stock');
+            $stock = Mage::getModel('firegento_multistock/stock');
             $stock->setData($postData);
             //we are in editing mode.
             if ($stockId) {
                 $stock->setId($stockId);
             }
-
+            $stock->save();
             try {
-                $stock->save();
                 Mage::getSingleton('adminhtml/session')->addSuccess($this->__('The stock has been saved.'));
             } catch (Mage_Core_Exception $e) {
                 Mage::getSingleton('adminhtml/session')->addError($e->getMessage());

--- a/src/app/design/adminhtml/default/default/layout/firegento_multistock.xml
+++ b/src/app/design/adminhtml/default/default/layout/firegento_multistock.xml
@@ -67,4 +67,18 @@
             </block>
         </reference>
     </adminhtml_stock_edit>
+    <adminhtml_stock_new>
+        <reference name="content">
+            <block type="firegento_multistock/adminhtml_stock_edit" name="stock.edit"/>
+        </reference>
+        <reference name="left">
+            <block type="firegento_multistock/adminhtml_stock_edit_tabs" name="stock.tabs">
+                <action method="addTab">
+                    <name>form_section_stock</name>
+                    <block>firegento_multistock/adminhtml_stock_edit_tab_general</block>
+                </action>
+            </block>
+        </reference>
+    </adminhtml_stock_new>
+
 </layout>


### PR DESCRIPTION
Separated Creation of new and editing of existing stock items. Because of automatically set stock_id it was not possible to save new items.
